### PR TITLE
feat: add implementation to compute miner reward

### DIFF
--- a/core/models/utility_models.py
+++ b/core/models/utility_models.py
@@ -30,6 +30,7 @@ class QueryResult(BaseModel):
     task: str
     status_code: Optional[int]
     success: bool
+    reward: Optional[float]  # store reward to be used in
     created_at: datetime = Field(default_factory=datetime.now)
 
 


### PR DESCRIPTION
This update adds a reward system that encourages miners to stream tokens smoothly and steadily by calculating a reward based on the timing of each token. If tokens are sent too irregularly, a penalty is applied to reduce the reward. To handle cases where only one token is sent at the end, we’ve added logic that skips the smoothness check and instead assigns a reward based on response time alone, ensuring fair treatment for these cases. The smooth interval threshold, penalty factor, and minimum reward are now adjustable parameters, allowing for flexible tuning across different tasks or network conditions. The reward calculation considers the number of tokens and response time, with a penalty factor applied based on the proportion of smooth to non-smooth intervals; this ensures that smoother, faster streams earn higher rewards. The adjusted_reward can be stored in the database for each miner, providing a cumulative performance record. This change promotes high-quality streaming by rewarding consistent, real-time streaming and offering customization for various use cases.