### PR TITLE
Detect Non-Smooth SSE Streams by Measuring Interval Dispersion

### DIFF
--- a/validator/query_node/src/query/streaming.py
+++ b/validator/query_node/src/query/streaming.py
@@ -79,6 +79,33 @@ def construct_500_query_result(node: Node, task: str) -> utility_models.QueryRes
     return query_result
 
 
+# def gini_coefficient(intervals: List[float]) -> float:
+#     """Calculates the Gini coefficient for a list of intervals."""
+#     intervals = np.array(intervals)
+#     sorted_intervals = np.sort(intervals)
+#     n = len(intervals)
+#     cumulative_intervals = np.cumsum(sorted_intervals)
+#     gini = (n + 1 - 2 * np.sum(cumulative_intervals) / cumulative_intervals[-1]) / n
+#     return gini
+
+
+# async def consume_generator_with_penalty():
+#     """Pseudocode implementation."""
+#     last_time = start_time
+#     intervals = []
+
+#     async for chunks in stream:
+#         if len(chunks) > 1:
+#             intervals.append(time.time() - last_time)
+#             intervals.extend([0] * (len(chunks) - 1))
+#         else:
+#             intervals.append(time.time() - last_time)
+        
+#         last_time = time.time()
+
+#     if gini_coefficient(intervals) > threshold:
+#         apply_penalty()
+
 async def consume_generator(
     config: Config,
     generator: AsyncGenerator,


### PR DESCRIPTION
Purpose:

This PR contains pseudocode to detect uneven SSE streams from miners by measuring the dispersion of time intervals between chunks. The goal is to identify and penalize streams that show irregularities in event timing.

## Objectives:
- Measure dispersion in time intervals between chunk.
- Detect two patterns of concern:
   - Single Extreme Outlier: A large delay followed by a burst of chunks (all tokens arrive in the end).
   - Two-Peak Distribution: Chunks arriving in clusters separated by pauses (chunks arrive in batches).
- Use a normalized statistic to enable configurable thresholding for penalties.
- The statistic preferably should have an online implementation to avoid excess memory usage. The current code stores all chunks in memory anyway so it's not needed at the moment, but nice to have for the future optimization.

## Approach:
Use the Gini coefficient to measure inequality in interval lengths:
- Treat batched events (len(loaded_jsons) > 1) as consecutive zero intervals.
- Calculate Gini on intervals to quantify dispersion, where higher values indicate non-smooth distributions.
- Trigger a penalty if the Gini coefficient exceeds a set threshold.

## Pseudocode

```
def gini_coefficient(intervals: List[float]) -> float:
    """Calculates the Gini coefficient for a list of intervals."""
    intervals = np.array(intervals)
    sorted_intervals = np.sort(intervals)
    n = len(intervals)
    cumulative_intervals = np.cumsum(sorted_intervals)
    gini = (n + 1 - 2 * np.sum(cumulative_intervals) / cumulative_intervals[-1]) / n
    return gini


async def consume_generator_with_penalty():
    """Pseudocode implementation."""
    last_time = start_time
    intervals = []

    async for chunks in stream:
        if len(chunks) > 1:
            intervals.append(time.time() - last_time)
            intervals.extend([0] * (len(chunks) - 1))
        else:
            intervals.append(time.time() - last_time)
        
        last_time = time.time()

    if gini_coefficient(intervals) > threshold:
        apply_penalty()

```