### PR TITLE
Making text in synthetic queries more natural, clean & enhance verbosity

### DIFF
--- a/validator/control_node/src/main.py
+++ b/validator/control_node/src/main.py
@@ -17,7 +17,7 @@ logger = get_logger(__name__)
 
 async def main() -> None:
     nltk.download('punkt_tab')
-    
+    nltk.download('stopwords')
     config = load_config()
     await config.psql_db.connect()
 

--- a/validator/control_node/src/synthetics/synthetic_generation_funcs.py
+++ b/validator/control_node/src/synthetics/synthetic_generation_funcs.py
@@ -64,8 +64,8 @@ async def generate_chat_synthetic(model: str, task_config: Any, word_to_token: f
             top_p=1,
         )
 
-        logger.info(f"Generated {total_n_words} words chat synth in {round(time()-start, 3)}s")
-        logger.info(f"payload : {payload}")
+        logger.debug(f"Generated {total_n_words} words chat synth in {round(time()-start, 3)}s")
+        logger.debug(f"payload : {payload}")
         return payload
 
     except Exception as e:
@@ -99,8 +99,8 @@ async def generate_chat_comp_synthetic(model: str, task_config: Any, word_to_tok
             top_p=1,
         )
 
-        logger.info(f"Generated {total_n_words} words chat completion synth in {round(time()-start, 3)}s")
-        logger.info(f"payload : {payload}")
+        logger.debug(f"Generated {total_n_words} words chat completion synth in {round(time()-start, 3)}s")
+        logger.debug(f"payload : {payload}")
         return payload
 
     except Exception as e:

--- a/validator/control_node/src/synthetics/synthetic_generation_funcs.py
+++ b/validator/control_node/src/synthetics/synthetic_generation_funcs.py
@@ -88,7 +88,7 @@ async def generate_chat_comp_synthetic(model: str, task_config: Any, word_to_tok
         total_n_words = total_n_words if total_n_words > 0 else 20
         logger.debug(f"generating prompt with {total_n_words} words for synth")
 
-        message = await sutils.generate_text(synth_corpus, total_n_words)
+        message = await sutils.generate_text(synth_corpus, total_n_words, completions=True)
 
         payload = payload_models.CompletionPayload(
             prompt=message,

--- a/validator/control_node/src/synthetics/synthetic_generation_funcs.py
+++ b/validator/control_node/src/synthetics/synthetic_generation_funcs.py
@@ -64,8 +64,8 @@ async def generate_chat_synthetic(model: str, task_config: Any, word_to_token: f
             top_p=1,
         )
 
-        logger.info(f"Generated {total_n_words} words chat synth in {round(time()-start, 3)}s")
-        logger.info(f"payload : {payload}")
+        logger.debug(f"Generated {total_n_words} words chat synth in {round(time()-start, 3)}s")
+        logger.debug(f"payload : {payload}")
         return payload
 
     except Exception as e:

--- a/validator/control_node/src/synthetics/synthetic_generation_funcs.py
+++ b/validator/control_node/src/synthetics/synthetic_generation_funcs.py
@@ -64,8 +64,8 @@ async def generate_chat_synthetic(model: str, task_config: Any, word_to_token: f
             top_p=1,
         )
 
-        logger.debug(f"Generated {total_n_words} words chat synth in {round(time()-start, 3)}s")
-        logger.debug(f"payload : {payload}")
+        logger.info(f"Generated {total_n_words} words chat synth in {round(time()-start, 3)}s")
+        logger.info(f"payload : {payload}")
         return payload
 
     except Exception as e:

--- a/validator/control_node/src/synthetics/synthetic_generation_funcs.py
+++ b/validator/control_node/src/synthetics/synthetic_generation_funcs.py
@@ -65,7 +65,7 @@ async def generate_chat_synthetic(model: str, task_config: Any, word_to_token: f
         )
 
         logger.info(f"Generated {total_n_words} words chat synth in {round(time()-start, 3)}s")
-        logger.debug(f"payload : {payload}")
+        logger.info(f"payload : {payload}")
         return payload
 
     except Exception as e:

--- a/validator/control_node/src/synthetics/synthetic_generation_funcs.py
+++ b/validator/control_node/src/synthetics/synthetic_generation_funcs.py
@@ -25,11 +25,11 @@ logger = get_logger(__name__)
 async def generate_chat_synthetic(model: str, task_config: Any, word_to_token: float = 4) -> payload_models.ChatPayload:
     start = time()
     synth_corpus = sutils.get_synth_corpus()
-    
+
     try:
         total_n_words = sutils.get_random_int_from_dist(size=1, max_value=task_config.orchestrator_server_config.load_model_config['max_model_len']//word_to_token)
         if total_n_words.size == 0:
-            total_n_words = 1000 
+            total_n_words = 1000
         else:
             total_n_words = int(total_n_words[0])
         total_n_words = total_n_words if total_n_words > 0 else 20
@@ -64,10 +64,10 @@ async def generate_chat_synthetic(model: str, task_config: Any, word_to_token: f
             top_p=1,
         )
 
-        logger.debug(f"Generated {total_n_words} words chat synth in {round(time()-start, 3)}s")
-        logger.debug(f"prompt : {messages}")
+        logger.info(f"Generated {total_n_words} words chat synth in {round(time()-start, 3)}s")
+        logger.debug(f"payload : {payload}")
         return payload
-    
+
     except Exception as e:
 
         logger.error("Error in new version of generate_chat_synthetic: %s", e)
@@ -78,18 +78,18 @@ async def generate_chat_synthetic(model: str, task_config: Any, word_to_token: f
 async def generate_chat_comp_synthetic(model: str, task_config: Any, word_to_token: float = 4) -> payload_models.CompletionPayload:
     start = time()
     synth_corpus = sutils.get_synth_corpus()
-    
+
     try:
         total_n_words = sutils.get_random_int_from_dist(size=1, max_value=task_config.orchestrator_server_config.load_model_config['max_model_len']//word_to_token)
         if total_n_words.size == 0:
-            total_n_words = 1000 
+            total_n_words = 1000
         else:
             total_n_words = int(total_n_words[0])
         total_n_words = total_n_words if total_n_words > 0 else 20
         logger.debug(f"generating prompt with {total_n_words} words for synth")
 
         message = await sutils.generate_text(synth_corpus, total_n_words)
-        
+
         payload = payload_models.CompletionPayload(
             prompt=message,
             temperature=round(random.random(), 1),
@@ -99,10 +99,10 @@ async def generate_chat_comp_synthetic(model: str, task_config: Any, word_to_tok
             top_p=1,
         )
 
-        logger.debug(f"Generated {total_n_words} words chat completion synth in {round(time()-start, 3)}s")
-        logger.debug(f"prompt : {message}")
+        logger.info(f"Generated {total_n_words} words chat completion synth in {round(time()-start, 3)}s")
+        logger.info(f"payload : {payload}")
         return payload
-    
+
     except Exception as e:
 
         logger.error("Error in new version of generate_chat_comp_synthetic: %s", e)

--- a/validator/utils/synthetic/synthetic_utils.py
+++ b/validator/utils/synthetic/synthetic_utils.py
@@ -79,7 +79,7 @@ async def get_random_text_from_queue():
     try:
         if not random_text_queue.empty():
             text = await random_text_queue.get()
-            return clean_text(text)
+            return text
         return None
     except Exception as e:
         logger.error(f"Error retrieving text from queue: {e}")

--- a/validator/utils/synthetic/synthetic_utils.py
+++ b/validator/utils/synthetic/synthetic_utils.py
@@ -85,7 +85,7 @@ async def get_random_text_from_queue():
         logger.error(f"Error retrieving text from queue: {e}")
         return None
 
-async def generate_text(corpus, n_words):
+async def generate_text(corpus, n_words, completions=False):
     random.seed(time()%10000)
     generated_text_parts = []
 
@@ -130,7 +130,7 @@ async def generate_text(corpus, n_words):
     merged_text = ' '.join(generated_text_parts)
     possible_endings = ['.', '!', '?', '...']
 
-    if merged_text and merged_text[-1] not in possible_endings:
+    if merged_text and merged_text[-1] not in possible_endings and not completions:
         if random.choice([True, False]):
             merged_text += random.choice(possible_endings)
 

--- a/validator/utils/synthetic/synthetic_utils.py
+++ b/validator/utils/synthetic/synthetic_utils.py
@@ -85,7 +85,7 @@ async def get_random_text_from_queue():
         logger.error(f"Error retrieving text from queue: {e}")
         return None
 
-async def generate_text(corpus, n_words, completions=False):
+async def generate_text(corpus: dict, n_words: int, completions : bool = False):
     random.seed(time()%10000)
     generated_text_parts = []
 


### PR DESCRIPTION
- cleaning generated synth texts from doubled spaces, \t, weird chars, etc
- splitting sentences by stop words in order for them to make more sense
- for completions, don't randomly add punctuation at the end of the text (causes rose rogue tends to return eos token directly oftenly)